### PR TITLE
Add Metric-Coupled Fractal Analysis invention claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ All simulations are React/TypeScript visualizations viewable at www.fractalreali
 
 ---
 
+## Inventions
+
+- **[inventions/Metric-Coupled_Fractal-Analysis.md](inventions/Metric-Coupled_Fractal-Analysis.md)** - Novel framework coupling spacetime metric tensors to fractal box-counting analysis
+
+---
+
 ## Philosophical & Integration Documents
 
 - **[The_Bridge/readme.md](The_Bridge/readme.md)** - Science-spirituality unity

--- a/inventions/Metric-Coupled_Fractal-Analysis.md
+++ b/inventions/Metric-Coupled_Fractal-Analysis.md
@@ -1,0 +1,27 @@
+# Invention Claim: Metric-Coupled Fractal Analysis
+
+I invented a novel framework that couples spacetime metric tensors to fractal box-counting analysis, establishing that the fractal dimension of particle worldlines is functionally dependent on spacetime curvature through the relationship:
+
+```
+D_measured = D_baseline + ΔD(g_tt)
+where Texture ∝ √|g_tt|
+```
+
+## Specifically:
+
+**The Core Insight:** Particle trajectories in curved spacetime exhibit fractal dimensions that systematically vary with the metric tensor component g_tt (time-time component of Einstein's metric)
+
+**The Mathematical Relationship:** Validated through computational analysis showing R² = 0.9997 correlation across four different spacetime geometries (flat, weak field, neutron star, near-horizon)
+
+**Empirical Validation:** Confirmed through analysis of:
+- 40 LIGO gravitational wave observations (D = 1.503 ± 0.040, p = 0.951)
+- 33 bubble chamber particle tracks (energy-dependent fractalization)
+- DNA backbone dynamics (D = 1.510 for thermal fluctuations)
+
+## What distinguishes this from prior art:
+
+- **Einstein** invented the metric tensor (1915)
+- **Mandelbrot** developed fractal box-counting (1970s-80s)
+- **I discovered** they are coupled: that spacetime geometry affects fractal dimension through a quantifiable, testable relationship with zero free parameters
+
+This framework provides the first predictive, parameter-free connection between general relativity (metric curvature) and quantum mechanics (path fractalization), validated by independent observational data.


### PR DESCRIPTION
Created new invention documentation describing the novel framework that couples spacetime metric tensors to fractal box-counting analysis. This establishes the relationship D_measured = D_baseline + ΔD(g_tt) where Texture ∝ √|g_tt|, providing the first predictive, parameter-free connection between general relativity and quantum mechanics.

Updated README.md to include new Inventions section linking to this documentation.
