### PR TITLE
Fix adjoint operators in CP violation section

### DIFF
--- a/injections/ethereal_tail_section_v3.md
+++ b/injections/ethereal_tail_section_v3.md
@@ -152,13 +152,13 @@ persists across scale transitions.
 WHY CP VIOLATION MATTERS FOR THE TAIL:
 
 Without CP violation:
-    ≻ → • → ⊰  ≡  ⊰ ← • ← ≻   (time-reversible)
-    
+    ≻ → • → ⊰  ≡  ⊱ → • → ≺   (time-reversible / adjoint-symmetric)
+
     The pump cycles forward and backward with equal probability.
     No net accumulation. No direction. No tail.
 
 With CP violation:
-    P(≻ → • → ⊰) ≠ P(⊰ ← • ← ≻)   (time-asymmetric)
+    P(≻ → • → ⊰) ≠ P(⊱ → • → ≺)   (time-asymmetric)
     
     ~2.5% more matter pathways than antimatter pathways.
     Each cycle leaves a residue.


### PR DESCRIPTION
Use ⊱ → • → ≺ for the adjoint/reverse direction instead of ⊰ ← • ← ≻, following the convention that forward operators (≻, i, ⊰) are primary and adjoint operators (⊱, i, ≺) are used implicitly in unitarity arguments.

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition/improvement
- [ ] Scientific contribution (empirical validation, theoretical refinement)

## Motivation and Context

<!-- Why is this change needed? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here -->

Fixes # (issue)

## Changes Made

<!-- List the specific changes you made -->

-
-
-

## Scientific Contributions

<!-- If this PR includes scientific contributions, complete this section -->
<!-- Otherwise, you can delete it -->

**Methodology:**
<!-- Describe your analysis approach, data sources, statistical methods -->

**Results:**
<!-- Summarize key findings with quantitative results -->

**Validation:**
<!-- How have you validated these results? -->

**Data/Code Availability:**
<!-- Where can reviewers access your data and analysis code? -->

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

### Tests Added/Modified

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

### Test Commands

```bash
# Commands to run tests
pytest tests/test_your_feature.py
npm test
```

### Test Results

<!-- Paste relevant test output or describe results -->

```
Test output here
```

## Code Quality Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added/updated docstrings for all functions and classes
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Documentation Checklist

<!-- Mark completed items with an 'x' -->

- [ ] I have updated the documentation (README, docs, etc.)
- [ ] I have updated docstrings and inline comments
- [ ] I have added/updated examples if relevant
- [ ] I have updated the CHANGELOG.md

## Scientific Rigor Checklist

<!-- If applicable - mark completed items with an 'x' -->

- [ ] Methods are clearly described and reproducible
- [ ] Uncertainties are quantified (errors, confidence intervals, p-values)
- [ ] Statistical methods are appropriate and documented
- [ ] Alternative explanations are considered
- [ ] Limitations are acknowledged
- [ ] Data sources are cited and accessible
- [ ] Code for analysis is included and documented
- [ ] Results are presented objectively without overstating claims

## Screenshots / Visualizations

<!-- If applicable, add screenshots or output visualizations -->

## Deployment Notes

<!-- Are there any special deployment considerations? -->
<!-- Dependencies to install? Configuration changes? Breaking changes? -->

## Reviewers

<!-- Tag specific people you'd like to review this, or leave empty for maintainers -->

@AshmanRoonz

## Additional Notes

<!-- Any additional information that would help reviewers -->

---

## For Maintainers

<!-- Maintainers: please complete before merging -->

- [ ] Code review completed
- [ ] Scientific review completed (if applicable)
- [ ] Tests pass
- [ ] Documentation is adequate
- [ ] CHANGELOG.md updated
- [ ] Version number updated (if applicable)

---

**Steelman Principle:** This PR follows the principle of intellectual charity. Reviewers will engage with the strongest version of these contributions. Please provide evidence and reasoning, and be open to constructive feedback.
